### PR TITLE
Modify yaml encoding to segregate serialize-encoded data from everything else

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,8 @@ Serialize Changelog
 ----------------
 
 - Added support for simplejson package https://pypi.org/project/simplejson/
-- Fixed bug in yaml support.
+- Change yaml support to support objects using __reduce__
+- Renamed the existing 'yaml' format to 'yaml:legacy'
 
 
 0.1 (2016-01-28)

--- a/serialize/__init__.py
+++ b/serialize/__init__.py
@@ -20,7 +20,8 @@ _MODULES = ('bson',
             'phpserialize',
             'pickle',
             'serpent',
-            'yaml')
+            'yaml',
+            'yaml_legacy')
 
 for name in _MODULES:
     try:

--- a/serialize/yaml.py
+++ b/serialize/yaml.py
@@ -21,8 +21,14 @@ except ImportError:
     raise
 
 
-# BUGBUG: these are a global namespace, so we need a unique URL/tag to use here...
-SERIALIZED_TAG = 'tag:github.com/hgrecco/serialize,2019:python/serialized-encoded'
+# Note: these tags a global namespace, so we need a unique URL/tag to use here.
+#
+# Pyyaml uses "tag:yaml.org,2002:...", some of which are defined by
+# yaml.org/spec/..., but the python-specific ones (like python/tuple,
+# python/complex, etc) seem to be their own, and probably should have used the
+# hostname pyyaml.org. Serialize's github homepage ought to be a pretty stable
+# URL we can use.
+SERIALIZED_TAG = 'tag:github.com/hgrecco/serialize,2019:python/serialize-encode'
 
 class Dumper(yaml.Dumper):
     def represent_serialized(self, data):
@@ -32,7 +38,7 @@ class Loader(yaml.Loader):
     def construct_serialized(self, node):
         assert node.tag == SERIALIZED_TAG
         assert isinstance(node, MappingNode)
-        dct = self.construct_mapping(node, deep=True) # BUGBUG: appropriate deep value?
+        dct = self.construct_mapping(node, deep=True)
         return all.decode(dct)
 
 

--- a/serialize/yaml_legacy.py
+++ b/serialize/yaml_legacy.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+    serialize.yaml
+    ~~~~~~~~~~~~~~
+
+    Helpers for Serpent Serialization.
+
+    See https://pypi.python.org/pypi/pyyaml for more details.
+
+    :copyright: (c) 2016 by Hernan E. Grecco.
+    :license: BSD, see LICENSE for more details.
+"""
+
+from . import all
+
+try:
+    import yaml
+    from yaml.constructor import MappingNode
+except ImportError:
+    all.register_unavailable('yaml', pkg='pyyaml')
+    raise
+
+
+class Dumper(yaml.Dumper):
+
+    def represent_data(self, data):
+        return super().represent_data(all.encode(data))
+
+
+class Loader(yaml.Loader):
+
+    def construct_object(self, node, deep=False):
+
+        if not isinstance(node, MappingNode):
+            return super().construct_object(node, deep)
+
+        dct = super().construct_mapping(node, deep)
+        return all.decode(dct)
+
+
+def dumps(obj):
+    return yaml.dump(obj, Dumper=Dumper).encode('utf-8')
+
+
+def loads(content):
+    return yaml.load(content.decode('utf-8'),
+                     Loader=Loader)
+
+all.register_format('yaml', dumps, loads)
+

--- a/serialize/yaml_legacy.py
+++ b/serialize/yaml_legacy.py
@@ -3,7 +3,9 @@
     serialize.yaml
     ~~~~~~~~~~~~~~
 
-    Helpers for Serpent Serialization.
+    Helpers for YAML (legacy) Serialization.
+
+    This format is compatible with the 'yaml' format from version 0.1 of serialize.yaml.
 
     See https://pypi.python.org/pypi/pyyaml for more details.
 
@@ -17,7 +19,7 @@ try:
     import yaml
     from yaml.constructor import MappingNode
 except ImportError:
-    all.register_unavailable('yaml', pkg='pyyaml')
+    all.register_unavailable('yaml:legacy', pkg='pyyaml')
     raise
 
 
@@ -46,5 +48,4 @@ def loads(content):
     return yaml.load(content.decode('utf-8'),
                      Loader=Loader)
 
-all.register_format('yaml', dumps, loads)
-
+all.register_format('yaml:legacy', dumps, loads)


### PR DESCRIPTION
PyYaml has a facility to add custom tags and handlers for specific object types (similar to serialize's register_class functionality).  This modifies serialize to use that API directly to trigger its internal encoding/decoding.

This addresses a specific problem where objects (like numpy arrays/scalars) use the pickle __reduce__ api to serialize themselves.  Those python objects showed up as MappingNodes, and would be mis-decoded by serialize. Tagging encoded data explicitly avoids such conflicts.

The former yaml format is now available as yaml:legacy internally, and test cases are provided for the different types of __reduce__ serialization.