### PR TITLE
security: do not auto-select code-executing formats (pickle, dill) from a file extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ MANIFEST
 
 # WebDAV file system cache files
 .DAV/
+
+.venv/

--- a/serialize/all.py
+++ b/serialize/all.py
@@ -33,6 +33,14 @@ FORMATS = {}
 # :type: str -> str
 FORMAT_BY_EXTENSION = {}
 
+#: Formats that can execute arbitrary code while loading (e.g. pickle, dill).
+#: These are never auto-selected from a file extension: a caller must opt in by
+#: passing ``fmt=`` explicitly. This prevents a caller that only intends to read
+#: data (``serialize.load(path)``) from being silently routed to a code-executing
+#: deserializer just because of the file name/extension (CWE-502).
+# :type: set of str
+UNSAFE_FORMATS = set()
+
 #: Map registered classes to the corresponding to_builtin and from_builtin.
 # :type: type -> ClassHelper
 CLASSES = {}
@@ -70,7 +78,15 @@ def _get_format_from_ext(ext):
 
     ext = ext.lower()
     if ext in FORMAT_BY_EXTENSION:
-        return FORMAT_BY_EXTENSION[ext]
+        fmt = FORMAT_BY_EXTENSION[ext]
+        if fmt in UNSAFE_FORMATS:
+            raise ValueError(
+                "'%s' maps to the '%s' format, which can execute arbitrary code "
+                "while loading and therefore is not auto-selected from a file "
+                "extension. If the source is trusted, pass fmt='%s' explicitly."
+                % (ext, fmt, fmt)
+            )
+        return fmt
 
     valid = ", ".join(FORMAT_BY_EXTENSION.keys())
 
@@ -227,6 +243,7 @@ def register_format(
     loader=None,
     extension=MISSING,
     register_class=None,
+    unsafe=False,
 ):
     """Register an available serialization format.
 
@@ -249,6 +266,10 @@ def register_format(
     `serialize.register_class`. When a new format is registered,
     previously registered classes are called. It takes on argument, the
     class to register. See `serialize.yaml.py` for an example.
+
+    `unsafe` should be True for formats that can execute arbitrary code while
+    loading (e.g. pickle, dill). Such formats are never auto-selected from a
+    file extension; the caller must pass `fmt=` explicitly to use them (CWE-502).
     """
 
     # For simplicity. We do not allow to overwrite format.
@@ -303,6 +324,9 @@ def register_format(
         extension = fmt.split(":", 1)[0]
 
     FORMATS[fmt] = Format(extension, dumper, dumpser, loader, loadser, register_class)
+
+    if unsafe:
+        UNSAFE_FORMATS.add(fmt)
 
     if extension and extension not in FORMAT_BY_EXTENSION:
         FORMAT_BY_EXTENSION[extension.lower()] = fmt

--- a/serialize/dill.py
+++ b/serialize/dill.py
@@ -32,4 +32,4 @@ def load(fp):
     return dill.Unpickler(fp).load()
 
 
-all.register_format("dill", dumper=dump, loader=load)
+all.register_format("dill", dumper=dump, loader=load, unsafe=True)

--- a/serialize/pickle.py
+++ b/serialize/pickle.py
@@ -61,4 +61,4 @@ def load(fp):
     return pickle.Unpickler(fp).load()
 
 
-all.register_format("pickle", dumper=dump, loader=load)
+all.register_format("pickle", dumper=dump, loader=load, unsafe=True)

--- a/serialize/testsuite/test_basic.py
+++ b/serialize/testsuite/test_basic.py
@@ -9,6 +9,7 @@ from serialize import dump, dumps, load, loads, register_class
 from serialize.all import (
     FORMATS,
     UNAVAILABLE_FORMATS,
+    UNSAFE_FORMATS,
     _get_format,
     _get_format_from_ext,
     register_format,
@@ -125,6 +126,21 @@ def test_file_by_name(fmt):
 
     filename1 = "tmp." + fh.extension
 
+    if fmt in UNSAFE_FORMATS:
+        # code-executing formats are never auto-selected from the extension;
+        # dumping/loading without an explicit fmt must be refused.
+        try:
+            with pytest.raises(ValueError):
+                dump(obj, filename1)
+            dump(obj, filename1, fmt=fmt)
+            assert load(filename1, fmt=fmt) == obj
+            with pytest.raises(ValueError):
+                load(filename1)
+        finally:
+            if os.path.exists(filename1):
+                os.remove(filename1)
+        return
+
     try:
         dump(obj, filename1)
         obj1 = load(filename1)
@@ -152,6 +168,19 @@ def test_file_by_name_pathlib(fmt):
     filename1 = "tmp." + fh.extension
     filename1 = pathlib.Path(filename1)
 
+    if fmt in UNSAFE_FORMATS:
+        try:
+            with pytest.raises(ValueError):
+                dump(obj, filename1)
+            dump(obj, filename1, fmt=fmt)
+            assert load(filename1, fmt=fmt) == obj
+            with pytest.raises(ValueError):
+                load(filename1)
+        finally:
+            if filename1.exists():
+                filename1.unlink()
+        return
+
     try:
         dump(obj, filename1)
         obj1 = load(filename1)
@@ -176,6 +205,11 @@ def test_format_from_ext(fmt):
     if ":" in fmt:
         return
     fh = FORMATS[fmt]
+    if fmt in UNSAFE_FORMATS:
+        # code-executing formats are never auto-selected from a file extension
+        with pytest.raises(ValueError):
+            _get_format_from_ext(fh.extension)
+        return
     assert _get_format_from_ext(fh.extension) == fmt
 
 

--- a/serialize/testsuite/test_security.py
+++ b/serialize/testsuite/test_security.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""
+    serialize.testsuite.test_security
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Regression tests for the CWE-502 hardening: code-executing formats
+    (pickle, dill) must never be auto-selected from a file extension. A caller
+    that only intends to read data (``serialize.load(path)``) must not be
+    silently routed to a code-executing deserializer just because of the file
+    name/extension; using such a format requires an explicit ``fmt=``.
+"""
+
+import pickle
+
+import pytest
+
+import serialize
+from serialize.all import UNSAFE_FORMATS
+
+
+def test_pickle_and_dill_are_marked_unsafe():
+    assert "pickle" in UNSAFE_FORMATS
+    # dill is optional; only assert when it is available
+    from serialize.all import FORMATS
+
+    if "dill" in FORMATS:
+        assert "dill" in UNSAFE_FORMATS
+
+
+def test_load_pickle_by_extension_is_refused(tmp_path):
+    p = tmp_path / "data.pickle"
+    p.write_bytes(pickle.dumps({"answer": 42}))
+
+    # auto-detection by extension must refuse the code-executing pickle backend
+    with pytest.raises(ValueError):
+        serialize.load(str(p))
+
+    # ... but an explicit opt-in still works
+    assert serialize.load(str(p), fmt="pickle") == {"answer": 42}
+
+
+def test_dump_pickle_by_extension_is_refused(tmp_path):
+    p = tmp_path / "data.pickle"
+
+    with pytest.raises(ValueError):
+        serialize.dump({"answer": 42}, str(p))
+
+    serialize.dump({"answer": 42}, str(p), fmt="pickle")
+    assert serialize.load(str(p), fmt="pickle") == {"answer": 42}
+
+
+def test_dill_by_extension_is_refused(tmp_path):
+    dill = pytest.importorskip("dill")
+    p = tmp_path / "data.dill"
+    p.write_bytes(dill.dumps({"answer": 42}))
+
+    with pytest.raises(ValueError):
+        serialize.load(str(p))
+
+    assert serialize.load(str(p), fmt="dill") == {"answer": 42}
+
+
+def test_safe_formats_are_still_autodetected(tmp_path):
+    # a data-only format must keep working without an explicit fmt
+    p = tmp_path / "data.json"
+    serialize.dump({"answer": 42}, str(p))
+    assert serialize.load(str(p)) == {"answer": 42}


### PR DESCRIPTION
# PR: security — don't auto-select code-executing formats (pickle, dill) from a file extension

## What this fixes
`serialize.load(path)` / `serialize.dump(obj, path)` pick the backend purely from the file **extension**
(`_get_format_from_ext`). Because `pickle` and `dill` are registered with the `.pickle` / `.dill` extensions,
a caller who only intends to read *data* (`serialize.load(user_path)`) is silently routed to
`pickle.Unpickler(...).load()` / `dill.Unpickler(...).load()` — which execute arbitrary code — whenever the
path/extension is attacker-influenced. (CWE-502, Deserialization of Untrusted Data.)

This implements exactly the "explicit flag" hardening we discussed: code-executing backends are marked
`unsafe=True` and are **never auto-selected from an extension**; a caller must pass `fmt=` explicitly to use
them. Data formats (json, yaml, msgpack, …) are unchanged and keep auto-detecting.

## Changes
- `all.py`: new `UNSAFE_FORMATS` set; `register_format(..., unsafe=False)`; `_get_format_from_ext` raises a
  clear `ValueError` (telling the caller to pass `fmt=`) if the extension maps to an unsafe format.
- `pickle.py`, `dill.py`: `register_format(..., unsafe=True)`.
- `testsuite/test_basic.py`: the extension/auto-detection tests now assert the new behavior for unsafe formats.
- `testsuite/test_security.py`: new regression tests (pickle/dill refused by extension, explicit `fmt=` still
  works, safe formats still auto-detect).

`serialize.load(path, fmt="pickle")` still works for the trusted-input case.

Test suite: unchanged pass/fail vs `main` on `test_basic.py` (the pre-existing `test_round_trip` failures are
unrelated), plus the new `test_security.py` passes.

## Note on the YAML backend (the second vector in the report — your call on design)
The report also covered the `yaml` backends: `serialize/yaml.py` and `serialize/yaml_legacy.py` load with the
full, unsafe `yaml.Loader`, so a `.yaml` document containing `!!python/object/apply:os.system [...]` executes
code. I deliberately left the yaml change **out of this PR** because a clean fix needs a design decision that's
yours to make (you mentioned wanting a better API here). What I found while testing:

- `yaml.FullLoader` blocks the RCE tags (`!!python/object/apply` / `new` / `module`) while still supporting
  `!!python/tuple` etc. `yaml_legacy` works perfectly under `FullLoader` (all round-trips pass, RCE blocked).
- The main `yaml` backend serializes registered classes as `!!python/object:...` (the default dumper path),
  which `FullLoader`/`SafeLoader` reject — so making it safe means changing how custom types are encoded
  (e.g. emit only the `SERIALIZED_TAG` mapping + a safe dumper), which is a wire-format decision.
- `SafeLoader` is fully safe but drops the ability to serialize arbitrary unregistered objects via yaml (that
  capability is what makes the RCE possible); only classes registered with `register_class` would round-trip.

Happy to send a follow-up PR for the yaml backend in whichever direction you prefer (FullLoader now + a safe
dumper later, or a stricter SafeLoader + register_class-only path). Just let me know.

---
Reported/authored by **hackchang**.
